### PR TITLE
Add VNC user to kali-trusted group

### DIFF
--- a/src/playbook.yml
+++ b/src/playbook.yml
@@ -36,6 +36,21 @@
     public_ssh_key: "{{ lookup('aws_ssm', '/vnc/ssh/rsa_public_key') }}"
     private_ssh_key: "{{ lookup('aws_ssm', '/vnc/ssh/rsa_private_key') }}"
 
+- hosts: all
+  name: Add VNC user to kali-trusted group
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Add VNC user to kali-trusted group
+      user:
+        append: yes
+        groups:
+          - kali-trusted
+        name: "{{ username }}"
+  vars:
+    # The username for the VNC user
+    username: "{{ lookup('aws_ssm', '/vnc/username') }}"
+
 - hosts: aws
   name: AWS-specific roles
   become: yes

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.0.8+build.1"
+__version__ = "0.0.9-rc.1"


### PR DESCRIPTION
## 🗣 Description

In this pull request we add the VNC user to the kali-trusted group.

## 💭 Motivation and Context

The assessors require sudo when VNC-ing into the Kali box.

## 🧪 Testing

All pre-commit hooks pass.  I was also able to build an AMI with these changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
