### PR TITLE
Fix permissions for /tools directory

### DIFF
--- a/src/playbook.yml
+++ b/src/playbook.yml
@@ -10,7 +10,6 @@
     - dev_ssh_access
     - persist_journald
     - htop
-    - kali
     - clamav
 
 - hosts: all
@@ -22,6 +21,17 @@
   vars:
     # The password for Neo4j
     password: "{{ lookup('aws_ssm', '/neo4j/password') }}"
+
+- hosts: all
+  name: Install other Kali tools
+  become: yes
+  become_method: sudo
+  roles:
+    - kali
+  vars:
+    # The group that should own the tools installed to /target.  The
+    # VNC user is in this group.
+    group: kali-trusted
 
 - hosts: all
   name: Install VNC


### PR DESCRIPTION
## 🗣 Description

@KyleEvers pointed out in #5 that when logged in as the `vnc` user they cannot run the tools in the `/tools` directory.  In this PR I modify the code to set the group to `kali-trusted`, to which the `vnc` user already belongs.

This PR is linked to #5.

## 💭 Motivation and Context

The assessment folks must be able to run their tools.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
