### PR TITLE
Increase packer timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
           GITHUB_RELEASE_URL: ${{ github.event.release.html_url }}
+          AWS_MAX_ATTEMPTS: 240
         run: packer build --timestamp-ui src/packer.json
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v1


### PR DESCRIPTION
## 🗣 Description

This gives release builds 60 minutes to extract the AMI from the stopped instance and encrypt it, just like in the prerelease builds.

## 💭 Motivation and Context

I should have done this in #16, but forgot to.

## 🧪 Testing

All pre-commit hooks pass.  We know that this is required for prerelease builds, so it makes sense to do it for release builds too.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
