### PR TITLE
Increase length of time role can be assumed

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -77,7 +77,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_STAGING }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 7200 # 2 hours
       - name: Create machine image
         env:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_PRODUCTION }}
-          role-duration-seconds: 43200
+          role-duration-seconds: 7200 # 2 hours
       - name: Create machine image
         env:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_PRODUCTION }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 43200
       - name: Create machine image
         env:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}

--- a/src/packer.json
+++ b/src/packer.json
@@ -14,7 +14,7 @@
       "ami_regions": "",
       "associate_public_ip_address": true,
       "encrypt_boot": true,
-      "instance_type": "t2.small",
+      "instance_type": "t2.xlarge",
       "kms_key_id": "{{user `build_region_kms`}}",
       "launch_block_device_mappings": [
         {

--- a/terraform-test-user/main.tf
+++ b/terraform-test-user/main.tf
@@ -83,6 +83,9 @@ module "iam_user" {
     aws.images-staging-ssm    = aws.images-staging-ssm
   }
 
+  # This image can take a while to build, so we set the max session
+  # duration to 2 hours.
+  ec2amicreate_role_max_session_duration = 2 * 60 * 60
   ssm_parameters = [
     "/cyhy/dev/users",
     "/ssh/public_keys/*",


### PR DESCRIPTION
## 🗣 Description

We were seeing AMI creation fail after over an hour.  This PR consists of some changes we made to remedy that:
* Increase the time that the AMI creation role can be assumed to two hours.
* Increase the build instance to `t2.xlarge`.

## 💭 Motivation and Context

It must be possible to build the Kali AMI, as it is required in the COOL.

## 🧪 Testing

A production Kali AMI was successfully built using these changes.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
