### PR TITLE
Add a role to install chrony and configure it to use Amazon Time Sync Service

### DIFF
--- a/src/aws.yml
+++ b/src/aws.yml
@@ -5,6 +5,7 @@
   become_method: sudo
   roles:
     - amazon_ssm_agent
+    - chrony_aws
     - cloudwatch_agent
     # The instance types used for almost all the instances expose EBS
     # volumes as NVMe block devices, so that's why we need nvme here.

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -6,6 +6,8 @@
   name: banner
 - src: https://github.com/cisagov/ansible-role-bloodhound
   name: bloodhound
+- src: https://github.com/cisagov/ansible-role-chrony-aws
+  name: chrony_aws
 - src: https://github.com/cisagov/ansible-role-clamav
   name: clamav
 - src: https://github.com/cisagov/ansible-role-cloudwatch-agent


### PR DESCRIPTION
## 🗣 Description

This pull request adds [an Ansible role](https://github.com/cisagov/ansible-role-chrony-aws) to the Packer build that installs [chrony](https://chrony.tuxfamily.org/) and configures it to use the [Amazon Time Sync Service](https://aws.amazon.com/blogs/aws/keeping-time-with-amazon-time-sync-service/).

## 💭 Motivation and Context

Keeping system clocks in sync is important for Kerberos, and is in general just a good practice.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
