### PR TITLE
Fix broken installation of CrackMapExec

### DIFF
--- a/src/crackmapexec.yml
+++ b/src/crackmapexec.yml
@@ -1,10 +1,16 @@
 ---
-# The CrackMapExec dependency gssapi requires the krb5-config
-# executable from the libkrb5-dev package.
+# The following CrackMapExec dependencies require the specified
+# packages be installed:
+# * gssapi requires the krb5-config executable from the libkrb5-dev
+#   package
+# * aardwolf requires a Rust compiler, as the Python package is only
+#   available from PyPI.org as a source distribution (i.e., there is
+#   no wheel available for download)
 - name: Install CrackMapExec dependencies
   ansible.builtin.package:
     name:
       - libkrb5-dev
+      - rustc
 
 - name: Install CrackMapExec
   ansible.builtin.import_role:

--- a/src/crackmapexec.yml
+++ b/src/crackmapexec.yml
@@ -16,7 +16,8 @@
   ansible.builtin.import_role:
     name: assessment_tool
   vars:
-    archive_src: https://github.com/byt3bl33d3r/CrackMapExec/tarball/master
+    archive_src: >
+      https://github.com/Porchetta-Industries/CrackMapExec/tarball/master
     install_dir: /tools/CrackMapExec
     pip_packages:
       - .

--- a/src/crackmapexec.yml
+++ b/src/crackmapexec.yml
@@ -3,14 +3,10 @@
 # packages be installed:
 # * gssapi requires the krb5-config executable from the libkrb5-dev
 #   package
-# * aardwolf requires a Rust compiler, as the Python package is only
-#   available from PyPI.org as a source distribution (i.e., there is
-#   no wheel available for download)
 - name: Install CrackMapExec dependencies
   ansible.builtin.package:
     name:
       - libkrb5-dev
-      - rustc
 
 - name: Install CrackMapExec
   ansible.builtin.import_role:
@@ -18,8 +14,14 @@
   vars:
     archive_src: >
       https://github.com/Porchetta-Industries/CrackMapExec/tarball/master
+    # This is not a cargo project, although it requires a Rust
+    # compiler.
+    cargo_build: no
     install_dir: /tools/CrackMapExec
     pip_packages:
       - .
+    # Although this is a Python project, the dependency aardwolf
+    # requires a Rust compiler to build its native code.
+    rust: yes
     unarchive_extra_opts:
       - --strip-components=1

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -5,7 +5,6 @@
   name: amazon_ssm_agent
 - src: https://github.com/cisagov/ansible-role-assessment-tool
   name: assessment_tool
-  version: improvement/add-support-for-rust
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
 - src: https://github.com/cisagov/ansible-role-burp-suite-pro

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -5,6 +5,7 @@
   name: amazon_ssm_agent
 - src: https://github.com/cisagov/ansible-role-assessment-tool
   name: assessment_tool
+  version: improvement/add-support-for-rust
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
 - src: https://github.com/cisagov/ansible-role-burp-suite-pro


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Pulls in the changes from cisagov/ansible-role-assessment-tool#42
- Leverages the aforementioned changes to fix a bug that is currently causing AMI builds to fail when installing [`CrackMapExec`](https://github.com/Porchetta-Industries/CrackMapExec)
- Modifies the URL from which `CrackMapExec` is installed

Note that we will build new staging and prod COOL AMIs after pulling these changes into #126.

## 💭 Motivation and context ##

- Resolves #124.
- The old URL from which `CrackMapExec` was being installed now redirects to the new one, so we may as well get the code from the true source.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to using the default branch of [cisagov/ansible-role-assessment-tool](https://github.com/cisagov/ansible-role-assessment-tool) once cisagov/ansible-role-assessment-tool#42 is merged.
