### PR TITLE
Re-enable the GitHubSecurityLab/actions-permissions/monitor action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,12 +245,10 @@ jobs:
           # - arm64
           - x86_64
     steps:
-      # If we use this proxy then the calls to the AWS API on
-      # localhost fail.
-      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      #   with:
-      #     # Uses the organization variable unless overridden
-      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,12 +52,10 @@ jobs:
           # - arm64
           - x86_64
     steps:
-      # If we use this proxy then the calls to the AWS API on
-      # localhost fail.
-      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      #   with:
-      #     # Uses the organization variable unless overridden
-      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,10 @@ jobs:
           # - arm64
           - x86_64
     steps:
-      # If we use this proxy then the calls to the AWS API on
-      # localhost fail.
-      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      #   with:
-      #     # Uses the organization variable unless overridden
-      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2


### PR DESCRIPTION
## 🗣 Description ##

This pull request re-enables the [GitHubSecurityLab/actions-permissions/monitor](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor) action.

## 💭 Motivation and context ##

With the merge of GitHubSecurityLab/actions-permissions#34, this proxy no longer interferes with AWS API or `boto3` calls.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.