### PR TITLE
Use FQCN and new name for Ansible lookup

### DIFF
--- a/ansible/assessor_tools.yml
+++ b/ansible/assessor_tools.yml
@@ -9,7 +9,7 @@
     # The group that should own the tools installed to /target.  The
     # VNC user is in this group.
     group: kali-trusted
-    vnc_username: "{{ lookup('aws_ssm', '/vnc/username') }}"
+    vnc_username: "{{ lookup('amazon.aws.ssm_parameter', '/vnc/username') }}"
   tasks:
     - name: Install tarrell13/Auto-Egress-Assess
       ansible.builtin.include_role:
@@ -487,7 +487,7 @@
       ansible.builtin.import_tasks: bloodhound.yml
       vars:
         # The password for Neo4j
-        password: "{{ lookup('aws_ssm', '/neo4j/password') }}"
+        password: "{{ lookup('amazon.aws.ssm_parameter', '/neo4j/password') }}"
 
     - name: Install C2 Tool Collection
       ansible.builtin.import_tasks: c2_tool_collection.yml

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -8,7 +8,10 @@ collections:
   # - ansible-role-cobalt-strike (uses amazon.aws.s3_object)
   #
   # Also required by the following playbooks:
+  # - ansible/assessor_tools.yml (uses amazon.aws.ssm_parameter)
+  # - ansible/vnc.yml (uses amazon.aws.ssm_parameter)
   # - ansible/wazuh_agent.yml (uses amazon.aws.ssm_parameter)
+  # - ansible/xfce.yml (uses amazon.aws.ssm_parameter)
   - amazon.aws
   # Required by the following Ansible roles:
   # - ansible-role-amazon-efs-utils (uses community.general.json_query

--- a/ansible/vnc.yml
+++ b/ansible/vnc.yml
@@ -9,11 +9,11 @@
         name: vnc_server
       vars:
         # The user information and ssh keys for the VNC user
-        vnc_server_password: "{{ lookup('aws_ssm', '/vnc/password') }}"
+        vnc_server_password: "{{ lookup('amazon.aws.ssm_parameter', '/vnc/password') }}"
         vnc_server_private_ssh_key: |-
-          {{ lookup('aws_ssm', '/vnc/ssh/ed25519_private_key') }}
+          {{ lookup('amazon.aws.ssm_parameter', '/vnc/ssh/ed25519_private_key') }}
         vnc_server_public_ssh_key: |-
-          {{ lookup('aws_ssm', '/vnc/ssh/ed25519_public_key') }}
+          {{ lookup('amazon.aws.ssm_parameter', '/vnc/ssh/ed25519_public_key') }}
         vnc_server_user_groups:
           # Note that this means that the aws.yml playbook _must_ run
           # before this one, so that the efs_users group has been
@@ -24,4 +24,4 @@
         # users on all instances.  This helps us avoid UID/GID
         # collisions with files written to the EFS share.
         vnc_server_user_uid: 2048
-        vnc_server_username: "{{ lookup('aws_ssm', '/vnc/username') }}"
+        vnc_server_username: "{{ lookup('amazon.aws.ssm_parameter', '/vnc/username') }}"

--- a/ansible/xfce.yml
+++ b/ansible/xfce.yml
@@ -11,4 +11,4 @@
         # The users for whom a symlink to the COOL file share should
         # be created
         xfce_cool_usernames:
-          - "{{ lookup('aws_ssm', '/vnc/username') }}"
+          - "{{ lookup('amazon.aws.ssm_parameter', '/vnc/username') }}"


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Updates several playbooks to use the FQCN and the new name for the `amazon.aws.ssm_parameter` (formerly `aws_ssm`) Ansible lookup
- Updates the dependency notes in `ansible/requirements.yml` to add several playbooks that use `amazon.aws.ssm_parameter`

## 💭 Motivation and context ##

Gotta be correct!

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.